### PR TITLE
refactor(types): remove deprecated task.ts re-export

### DIFF
--- a/client/src/types/task.ts
+++ b/client/src/types/task.ts
@@ -1,2 +1,0 @@
-/** @deprecated Use `@/lib/schemas/task`. This file will be removed after CI passes in main. */
-export type { TaskUser, Task, TaskGroup, TaskStatus } from '@/lib/schemas/task';


### PR DESCRIPTION
Summary
- Removed legacy `client/src/types/task.ts` thin re-export
- All imports are already migrated to `@/lib/schemas/task`

Verification
- npm run build ✅
- npx tsc --noEmit (root) ✅
- npx tsc --noEmit -p client/tsconfig.json ✅
- grep audits: no "@/types/task" in code ✅

Notes
- `index.ts` continues to re-export the canonical schema task as intended
